### PR TITLE
First Pass at Material based sound tag system

### DIFF
--- a/SXL Mods.sln
+++ b/SXL Mods.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.202
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.1209
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BabboSettings", "BabboSettings\BabboSettings.csproj", "{28A548AB-7637-4193-8E31-E9646CBCA241}"
 EndProject
@@ -26,6 +26,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "References", "References", 
 		References\Unity.Postprocessing.Runtime.dll = References\Unity.Postprocessing.Runtime.dll
 		References\Unity.RenderPipelines.Core.Runtime.dll = References\Unity.RenderPipelines.Core.Runtime.dll
 		References\Unity.RenderPipelines.HighDefinition.Runtime.dll = References\Unity.RenderPipelines.HighDefinition.Runtime.dll
+		References\UnityEditor.dll = References\UnityEditor.dll
 		References\UnityEngine.AudioModule.dll = References\UnityEngine.AudioModule.dll
 		References\UnityEngine.CoreModule.dll = References\UnityEngine.CoreModule.dll
 		References\UnityEngine.ImageConversionModule.dll = References\UnityEngine.ImageConversionModule.dll
@@ -43,6 +44,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XLGraphicsUI", "XLGraphicsUI\XLGraphicsUI.csproj", "{D94EB69A-C1F8-44C1-86C5-0A1C2BC2E789}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XLGraphics", "XLGraphics\XLGraphics.csproj", "{54F746DD-62D2-4326-B8EC-27F8F1E831C2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XLUnity", "XLUnity\XLUnity.csproj", "{4946006C-2FCD-4496-8F94-120AE49E0E2B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +84,12 @@ Global
 		{54F746DD-62D2-4326-B8EC-27F8F1E831C2}.MyConfig|Any CPU.Build.0 = Release|Any CPU
 		{54F746DD-62D2-4326-B8EC-27F8F1E831C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54F746DD-62D2-4326-B8EC-27F8F1E831C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4946006C-2FCD-4496-8F94-120AE49E0E2B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4946006C-2FCD-4496-8F94-120AE49E0E2B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4946006C-2FCD-4496-8F94-120AE49E0E2B}.MyConfig|Any CPU.ActiveCfg = Release|Any CPU
+		{4946006C-2FCD-4496-8F94-120AE49E0E2B}.MyConfig|Any CPU.Build.0 = Release|Any CPU
+		{4946006C-2FCD-4496-8F94-120AE49E0E2B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4946006C-2FCD-4496-8F94-120AE49E0E2B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SoundMod/Patches/DeckSounds.cs
+++ b/SoundMod/Patches/DeckSounds.cs
@@ -1,4 +1,4 @@
-﻿using HarmonyLib;
+using HarmonyLib;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -65,11 +65,60 @@ namespace SoundMod.Patches
 	}
 	
 	[HarmonyPatch(typeof(EventManager), "ExitGrind")]
-    	static class EventManager_ExitGrind_Patch
-    	{
+    static class EventManager_ExitGrind_Patch
+    {
 		static void Postfix()
 		{
 	    		PlayerController.Instance.boardController.isSliding = false; // Force it for sliding out without popping.
 		}
-    	}
+    }
+
+	[HarmonyPatch(typeof(DeckSounds), "SetRollingVolFromRPS")]
+	static class DeckSounds_SetRollingVolFromRPS_Patch
+	{
+		static bool Prefix(ref PlayerController.SurfaceTags _surfaceTag, ref float rps)
+		{
+			LevelSoundManager lvlManager = GameObject.FindObjectOfType<LevelSoundManager>();  // Always grab the first component
+			if (!lvlManager) return true;  // Continue to original function, collection does not exist.
+
+			PlayerController player = PlayerController.Instance;
+			RaycastHit hit;
+			Vector3 direction = -player.skaterController.skaterTransform.up;
+			Ray ray = new Ray(player.boardController.boardTransform.position, direction);
+
+			if (!Physics.Raycast(ray, out hit)) return true; // Continue to original function, no ray hit no object below us.
+
+			MeshCollider meshCollider = hit.collider as MeshCollider;
+			MeshRenderer meshRenderer = hit.transform.GetComponent<MeshRenderer>();
+
+			if (!meshCollider || !meshCollider.sharedMesh) return true;  // Continue to original function if we don't have a mesh collider we can't continue.
+
+			Mesh mesh = meshCollider.sharedMesh;
+			if (mesh.subMeshCount <= 1) return true;  // Continue to original function. Single submesh means there's no alternative material.
+
+			int triangleIdx = hit.triangleIndex;
+			int[] lookupIdx = new int[3] { mesh.triangles[triangleIdx * 3], mesh.triangles[triangleIdx * 3 + 1], mesh.triangles[triangleIdx * 3 + 2] };
+
+			int submeshCount = mesh.subMeshCount;
+
+			for (int i = 0; i < submeshCount; ++i)
+			{
+				int[] tris = mesh.GetTriangles(i);
+				for (int j = 0; j < tris.Length; j += 3)
+				{
+					if (tris[j] == lookupIdx[0] &&
+						tris[j + 1] == lookupIdx[1] &&
+						tris[j + 2] == lookupIdx[2])
+					{
+						// Get the surface tag from the scriptable object by material
+						int tag = lvlManager.tagCollection.GetSurfaceTagByMaterial(meshRenderer.sharedMaterials[i]);
+						_surfaceTag = tag == 0 ? _surfaceTag : (PlayerController.SurfaceTags)tag;
+						return true;
+					}
+				}
+			}
+
+			return true;
+		}
+	}
 }

--- a/XLUnity/Components/LevelSoundManager.cs
+++ b/XLUnity/Components/LevelSoundManager.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using System.Linq;
+
+using UnityEngine;
+
+public class LevelSoundManager : MonoBehaviour
+{ 
+	public MaterialSoundTagCollection tagCollection;
+}

--- a/XLUnity/Editor/MaterialSoundTagCollectionEditor.cs
+++ b/XLUnity/Editor/MaterialSoundTagCollectionEditor.cs
@@ -1,0 +1,58 @@
+using System.Collections;
+using System.Collections.Generic;
+
+using UnityEngine;
+using UnityEditor;
+
+[CustomEditor(typeof(MaterialSoundTagCollection))]
+public class MaterialSoundTagCollectionEditor : Editor
+{
+	MaterialSoundTagCollection soundTagCollection;
+
+    void OnEnable() {
+		soundTagCollection = (MaterialSoundTagCollection)target;
+    }
+
+    public override void OnInspectorGUI()
+    {
+        EditorGUILayout.BeginVertical();
+        // Collection Label
+        EditorGUILayout.BeginHorizontal();
+        EditorGUILayout.LabelField($"{target.name}");
+        if (GUILayout.Button("Clean Collection")) {
+			soundTagCollection.Cleanse();
+        }
+        EditorGUILayout.EndHorizontal();
+        EditorGUILayout.Space(20);
+
+        if (GUILayout.Button("+ Add Item")) {
+			soundTagCollection.AddItem(null, SurfaceTag.None);
+        }
+        EditorGUILayout.Space(20);
+
+        // List<MaterialTagItem> collectionItems = soundTagCollection.ItemTags;
+		List<Material> materials = soundTagCollection.materials;
+		List<SurfaceTag> tags = soundTagCollection.tags;
+        List<MaterialTagItem> itemsForDelete = new List<MaterialTagItem>();
+
+        // Parameter settings
+        for (int i=0; i<materials.Count; ++i) {
+
+            EditorGUILayout.BeginHorizontal();
+            Material mat = (Material)EditorGUILayout.ObjectField(materials[i], typeof(Material), false);
+            SurfaceTag tag = (SurfaceTag)EditorGUILayout.EnumPopup(tags[i]);
+            soundTagCollection.UpdateItem(i, mat, tag);
+            if (GUILayout.Button("x")) {
+                itemsForDelete.Add(new MaterialTagItem(mat, tag));
+            }
+            EditorGUILayout.EndHorizontal();
+        }
+
+        // Purge items after iterative process
+        foreach(MaterialTagItem entry in itemsForDelete) {
+			soundTagCollection.RemoveItem(entry);
+        }
+
+		EditorGUILayout.EndVertical();
+    }
+}

--- a/XLUnity/MaterialTagItem.cs
+++ b/XLUnity/MaterialTagItem.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using UnityEngine;
+
+
+public enum SurfaceTag
+{
+	None = 0,
+	Concrete = 1,
+	Brick = 2,
+	Tarmac = 3,
+	Wood = 4,
+	Grass = 5
+}
+
+[Serializable]
+public class TagCollection
+{
+	public List<MaterialTagItem> tagItems = new List<MaterialTagItem>();
+
+	public int GetSurfaceTagByMaterial(string mat)
+	{
+		MaterialTagItem item = tagItems.Where(x => x.name == mat).FirstOrDefault();
+		return item != null ? 0 : item.tag;
+	}
+
+	public void LogContents()
+	{
+		Debug.Log($"{tagItems.Count}");
+		foreach (MaterialTagItem i in tagItems)
+		{
+			Debug.Log($"{i.name} {i.tag}");
+		}
+	}
+}
+
+[Serializable]
+public class MaterialTagItem
+{
+	public string name;
+	public int tag;
+	public Material mat;
+
+	public MaterialTagItem(string m, SurfaceTag t)
+	{
+		this.name = m;
+		this.tag = (int)t;
+		this.mat = null;
+	}
+
+	public MaterialTagItem(Material m, SurfaceTag t)
+	{
+		this.mat = m;
+		this.name = mat != null ? m.name : "";
+		this.tag = (int)t;
+	}
+}

--- a/XLUnity/Properties/AssemblyInfo.cs
+++ b/XLUnity/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("XLUnity")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("XLUnity")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4946006c-2fcd-4496-8f94-120ae49e0e2b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/XLUnity/ScriptableObjects/MaterialSoundTagCollection.cs
+++ b/XLUnity/ScriptableObjects/MaterialSoundTagCollection.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "MaterialSoundTagCollection", menuName = "SkaterXL/MaterialSoundTagCollection", order = 0)]
+public class MaterialSoundTagCollection : ScriptableObject
+{
+	public List<Material> materials;
+	public List<SurfaceTag> tags;
+		
+	public int GetSurfaceTagByMaterial(Material mat)
+	{
+		for (int i = 0; i < materials.Count; ++i)
+		{
+			if (materials.ElementAt(i) == mat)
+			{
+				return (int)tags.ElementAt(i);
+			}
+		}
+		return 0;
+	}
+
+	public void Cleanse()
+	{
+        var results = materials.Select((item, i) => new { index = i, item = item }).Where(p => p.item == null).Select(item => item.index);
+		
+        foreach (int idx in results)
+        {
+            materials.RemoveAt(idx);
+            tags.RemoveAt(idx);
+        }
+	}
+
+	public void AddItem(Material mat, SurfaceTag tag) {
+        materials.Add(mat);
+        tags.Add(tag);
+	}
+
+	public void UpdateItem(int idx, Material mat, SurfaceTag tag)
+	{
+        materials[idx] = mat;
+        tags[idx] = tag;
+	}
+
+	public void RemoveItem(MaterialTagItem item)
+	{
+		materials.Remove(item.mat);
+		tags.Remove((SurfaceTag)item.tag);
+	}
+}

--- a/XLUnity/XLUnity.csproj
+++ b/XLUnity/XLUnity.csproj
@@ -4,21 +4,20 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{0DB054B1-32D4-4857-AE41-93538D84FB53}</ProjectGuid>
+    <ProjectGuid>{4946006C-2FCD-4496-8F94-120AE49E0E2B}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SoundMod</RootNamespace>
-    <AssemblyName>SoundMod</AssemblyName>
+    <RootNamespace>XLUnity</RootNamespace>
+    <AssemblyName>XLUnity</AssemblyName>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\Skater XL\Mods\SoundMod\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -26,31 +25,24 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>D:\Steam\steamapps\common\Skater XL\Mods\SoundMod\</OutputPath>
+    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\References\0Harmony.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\References\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
-    <Reference Include="UnityEngine.AudioModule">
-      <HintPath>..\References\UnityEngine.AudioModule.dll</HintPath>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Xml.Serialization" />
+    <Reference Include="UnityEditor">
+      <HintPath>..\References\UnityEditor.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="UnityEngine">
+      <HintPath>..\References\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
@@ -61,9 +53,8 @@
       <HintPath>..\References\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>..\References\UnityEngine.PhysicsModule.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="UnityEngine.JSONSerializeModule">
+      <HintPath>..\References\UnityEngine.JSONSerializeModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>..\References\UnityEngine.UI.dll</HintPath>
@@ -73,32 +64,14 @@
       <HintPath>..\References\UnityEngine.UIModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UnityWebRequestWWWModule">
-      <HintPath>..\References\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityModManager">
-      <HintPath>..\References\UnityModManager.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Logger.cs" />
-    <Compile Include="Main.cs" />
-    <Compile Include="Patches\DeckSounds.cs" />
+    <Compile Include="Components\LevelSoundManager.cs" />
+    <Compile Include="Editor\MaterialSoundTagCollectionEditor.cs" />
+    <Compile Include="MaterialTagItem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Settings.cs" />
-    <Compile Include="SoundMod.cs" />
+    <Compile Include="ScriptableObjects\MaterialSoundTagCollection.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="README.md" />
-    <None Include="Resources\Info.json" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\XLUnity\XLUnity.csproj">
-      <Project>{4946006c-2fcd-4496-8f94-120ae49e0e2b}</Project>
-      <Name>XLUnity</Name>
-    </ProjectReference>
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
This sound tag system utilizes Serialized SO data representing mapping from material to tag index.

Data is collected every frame from a raycast down from a negative vector from the board controller location. This hit location must be a mesh collider for the resulting quad to be represented as a material at its approximate location.

Known Issues:
- Have not tested lower resolution Mesh Colliders in place of the higher point count visual mesh.
- Higher density meshes may take longer to iterate through the vertices to locate the triangle collected. An approach would be to precache ranges in which the materials are tied to. and instead of iterating through triangles, do a sanity check for materials that belong in the range the vertex resides.